### PR TITLE
Make README say to run diesel before cargo build

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ up with your local postgres install.
 Build it:
 
 ```bash
-$ cargo build
 $ cargo install diesel_cli
 $ diesel setup
+$ cargo build
 ```
 
 Clone down the Rust repository somewhere. I put mine in `~/src`:


### PR DESCRIPTION
If you run `cargo build` before the tables exist, you get this error:

```
error[E0432]: unresolved import `super::schema::commits`
  --> src/models.rs:18:5
   |
18 | use super::schema::commits;
   |     ^^^^^^^^^^^^^^^^^^^^^^ no `commits` in `schema`

error[E0432]: unresolved import `super::schema::releases`
  --> src/models.rs:29:5
   |
29 | use super::schema::releases;
   |     ^^^^^^^^^^^^^^^^^^^^^^^ no `releases` in `schema`

error[E0432]: unresolved import `schema::commits`
  --> src/lib.rs:31:9
   |
31 |     use schema::commits;
   |         ^^^^^^^^^^^^^^^ no `commits` in `schema`

error[E0432]: unresolved import `schema::releases`
  --> src/lib.rs:47:9
   |
47 |     use schema::releases;
   |         ^^^^^^^^^^^^^^^^ no `releases` in `schema`

error[E0277]: the trait bound `&models::NewCommit<'_>: diesel::query_builder::insert_statement::IntoInsertStatement<_, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::NoReturningClause>` is not satisfied
  --> src/lib.rs:40:33
   |
40 |     diesel::insert(&new_commit).into(commits::table)
   |                                 ^^^^ the trait `diesel::query_builder::insert_statement::IntoInsertStatement<_, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::NoReturningClause>` is not implemented for `&models::NewCommit<'_>`

error[E0277]: the trait bound `&models::NewRelease<'_>: diesel::query_builder::insert_statement::IntoInsertStatement<_, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::NoReturningClause>` is not satisfied
  --> src/lib.rs:53:34
   |
53 |     diesel::insert(&new_release).into(releases::table)
   |                                  ^^^^ the trait `diesel::query_builder::insert_statement::IntoInsertStatement<_, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::NoReturningClause>` is not implemented for `&models::NewRelease<'_>`

error: aborting due to 2 previous errors

error: Could not compile `contributors`.
```

This error is fixed by creating the tables, which is done by `diesel setup`, so that command should probably be moved before `cargo build` in the README.