### PR TITLE
Make sort more accurate - might fix #19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,7 @@
 name = "contributors"
 version = "0.1.0"
 dependencies = [
+ "caseless 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_codegen 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -12,6 +13,7 @@ dependencies = [
  "serde 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -53,6 +55,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "byteorder"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "caseless"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cfg-if"
@@ -868,6 +879,7 @@ dependencies = [
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "29b2aa490a8f546381308d68fc79e6bd753cd3ad839f7a7172897f1feedfa175"
+"checksum caseless 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7943e9a31ba2742c288cb755e66a2af03b708e3878c921d56204263270314f8a"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ serde_json = "0.8.4"
 diesel = "0.9.0"
 diesel_codegen = { version = "0.9.0", features = ["postgres"] }
 dotenv = "0.8.0"
+caseless = "0.1.2"
+unicode-normalization = "0.1.0"
 
 [dependencies.handlebars]
 version = "0.24.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,13 +10,19 @@ use diesel::pg::PgConnection;
 
 use dotenv::dotenv;
 
+extern crate caseless;
+extern crate unicode_normalization;
+
 use std::env;
+use std::cmp::Ordering;
 
 pub mod schema;
 pub mod models;
 
 use self::models::{Commit, NewCommit};
 use self::models::{Release, NewRelease};
+
+use unicode_normalization::UnicodeNormalization;
 
 pub fn establish_connection() -> PgConnection {
     dotenv().ok();
@@ -53,4 +59,52 @@ pub fn create_release(conn: &PgConnection, version: &str) -> Release {
     diesel::insert(&new_release).into(releases::table)
         .get_result(conn)
         .expect("Error saving new release")
+}
+
+
+fn char_cmp(a_char: char, b_char: char) -> Ordering {
+    let a = caseless::default_case_fold_str(&a_char.to_string());
+    let b = caseless::default_case_fold_str(&b_char.to_string());
+
+    let first_char = a.chars().nth(0).unwrap_or('{');
+
+    let order = if a == b && a.len() == 1 && 'a' <= first_char && first_char <= 'z' {
+        if a_char > b_char {
+            Ordering::Less
+        } else if a_char < b_char {
+            Ordering::Greater
+        } else {
+            Ordering::Equal
+        }
+    } else {
+        a.cmp(&b)
+    };
+
+    order
+}
+
+fn str_cmp(a_raw: &str, b_raw: &str) -> Ordering {
+    let a: Vec<char> = a_raw.nfkd().filter(|&c| (c as u32) < 0x300 || (c as u32) > 0x36f).collect();
+    let b: Vec<char> = b_raw.nfkd().filter(|&c| (c as u32) < 0x300 || (c as u32) > 0x36f).collect();
+
+    for (&a_char, &b_char) in a.iter().zip(b.iter()) {
+        match char_cmp(a_char, b_char) {
+            Ordering::Less => return Ordering::Less,
+            Ordering::Greater => return Ordering::Greater,
+            Ordering::Equal => {}
+        }
+    }
+
+    if a.len() < b.len() {
+        Ordering::Less
+    } else if a.len() > b.len() {
+        Ordering::Greater
+    } else {
+        Ordering::Equal
+    }
+}
+
+// TODO: switch this out for an implementation of the Unicode Collation Algorithm
+pub fn inaccurate_sort(strings: &mut Vec<String>) {
+    strings.sort_by(|a, b| str_cmp(&a, &b));
 }


### PR DESCRIPTION
I've implemented @lfairy's suggestions from https://github.com/steveklabnik/contributors/issues/19#issuecomment-272355781.

PostgreSQL does have support for Unicode collation, but it uses the `strcoll` function from the system's packaged C standard library, which apparently is broken on OS X. If you're using a Linux server, you might be able to use a query like `SELECT DISTINCT(author_name) FROM commits ORDER BY author_name COLLATE 'en_US'`. I don't think Diesel has support for `COLLATE`, though, so you might have to use a raw query.

If the [Rust bindings for ICU](https://github.com/servo/rust-icu) are ever finished, you'll be able to use ICU's implementation of the Unicode Collation Algorithm.

For now, I've implemented a string `cmp` function that

1. Decomposes each string into Unicode's Normalization Form Compatibility Decomposition (NFKD), which separates the diacritics from accented letters (for example, `É` to `E´`)
2. Filters out diacritics (so that letters like `É` will be considered equivalent to `E`) 
3. Performs Unicode case folding on each character, which normalizes all the characters to their lower case form.
4. For Latin characters that are equivalent at this point (ignoring case), any differences in the case-sensitive values of the characters are due to them being in different cases, so it sorts lowercase characters before uppercase characters.
5. All other characters are compared using the normal `cmp`

It's still not terribly accurate, especially not for non-Latin characters, but at least now it orders names like the following correctly:

- ashley
- Anderson
- elly
- Émile
- Eric

There's a hit on performance, especially for the all-time contributors page. Please let me know if there's anything I should do to speed it up.